### PR TITLE
Set CMake version to 1.0.0 and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-02-22
+
+### Added
+- Created repo and added the YARP device `ovrheadset` to expose on YARP the Oculus HMD and controllers. 
+  The device was moved from the YARP repo, to simplify mantainance and permit to easily compile it also against a binary distribution of YARP, see https://github.com/robotology/yarp/issues/2352 for more details.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(yarp-device-ovrheadset
         LANGUAGES CXX
-        VERSION 3.4.100)
+        VERSION 1.0.0)
 
 include(FeatureSummary)
 


### PR DESCRIPTION
As discussed in https://github.com/robotology/yarp-device-ovrheadset/issues/3 . This will permit to include this repo as part of robotology-superbuild release 2021.02 .