### PR TITLE
Switch to use upstream glfw CMake machinery instead of deprecated YCM  functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set(CMAKE_CXX_FLAGS "${YARP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 yarp_configure_plugins_installation(yarp-device-ovrheadset)
 
-find_package(GLFW3 REQUIRED)
+find_package(glfw3 NO_MODULE REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(LibOVR 1.19 REQUIRED)

--- a/src/devices/ovrheadset/CMakeLists.txt
+++ b/src/devices/ovrheadset/CMakeLists.txt
@@ -8,7 +8,7 @@ yarp_prepare_plugin(ovrheadset
   CATEGORY device
   TYPE yarp::dev::OVRHeadset
   INCLUDE OVRHeadset.h
-  DEPENDS "LibOVR_FOUND;GLFW3_FOUND;GLEW_FOUND;OpenGL_FOUND"
+  DEPENDS "LibOVR_FOUND;glfw3_FOUND;GLEW_FOUND;OpenGL_FOUND"
   INTERNAL
   QUIET
 )
@@ -77,7 +77,7 @@ target_link_libraries(yarp_ovrheadset
     YARP::YARP_math
     LibOVR::OVR
     GLEW::GLEW
-    GLFW3::GLFW3
+    glfw
     OpenGL::GL
 )
 


### PR DESCRIPTION
See https://github.com/robotology/ycm-cmake-modules/pull/441 .